### PR TITLE
Initialize sim crate with initial failing test

### DIFF
--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "sim"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/sim/tests/game_event_sys_test.rs
+++ b/sim/tests/game_event_sys_test.rs
@@ -1,0 +1,6 @@
+use sim::game_event::GameEventSys;
+
+#[test]
+fn can_construct_game_event_sys() {
+    let _ = GameEventSys::new();
+}


### PR DESCRIPTION
## Summary
- create the new `sim` Rust library crate scaffold
- add the first failing test covering `GameEventSys::new`

## Testing
- not run (new failing test)

------
https://chatgpt.com/codex/tasks/task_e_68c9a3aac918832a9740026693130c85